### PR TITLE
Fix bugs when updating website Content Tree

### DIFF
--- a/models/ContentTreeTranslation.php
+++ b/models/ContentTreeTranslation.php
@@ -182,10 +182,10 @@ class ContentTreeTranslation extends \yii\db\ActiveRecord
             }
 
             /* If alias has changed trigger CHANGE_ALIAS_PATH event.
-            *  This event update own and children's alias_path,file_manager_item's path,
+            *  This event update own alias_path and own file_manager_items' path,
             *  rename file folder name oldAlias to newAlias
             */
-            $aliasChanged && !$this->contentTree->link_id && $this->contentTree->depth > 0 && $this->trigger(self::CHANGE_ALIAS_PATH);
+            $aliasChanged && !$this->contentTree->link_id && $this->trigger(self::CHANGE_ALIAS_PATH);
 
             /* If translation creates and it has children trigger CHANGE_CHILDREN_PATH event.
             *  This event updates children's alias_path,file_manager_item's path,

--- a/models/ContentTreeTranslation.php
+++ b/models/ContentTreeTranslation.php
@@ -185,12 +185,12 @@ class ContentTreeTranslation extends \yii\db\ActiveRecord
             *  This event update own and children's alias_path,file_manager_item's path,
             *  rename file folder name oldAlias to newAlias
             */
-            $aliasChanged && !$this->contentTree->link_id && $this->trigger(self::CHANGE_ALIAS_PATH);
+            $aliasChanged && !$this->contentTree->link_id && $this->contentTree->depth > 0 && $this->trigger(self::CHANGE_ALIAS_PATH);
 
             /* If translation creates and it has children trigger CHANGE_CHILDREN_PATH event.
             *  This event updates children's alias_path,file_manager_item's path,
             */
-            $insert && $this->children && !$this->contentTree->link_id && $this->trigger(self::CHANGE_CHILDREN_PATH);
+            $insert && $this->children && !$this->contentTree->link_id && $this->contentTree->depth > 0 && $this->trigger(self::CHANGE_CHILDREN_PATH);
         }
         parent::afterSave($insert, $changedAttributes);
     }

--- a/models/WebsiteTranslation.php
+++ b/models/WebsiteTranslation.php
@@ -84,6 +84,7 @@ class WebsiteTranslation extends BaseTranslateModel
                     'claim_image' => 'claim_image',
                     'image' => 'image'
                 ],
+                'filePath' => '[[attribute_language]]/[[column]]_[[filename]].[[extension]]'
             ],
         ], parent::behaviors());
     }
@@ -94,6 +95,7 @@ class WebsiteTranslation extends BaseTranslateModel
     public function rules()
     {
         return [
+            [['title'], 'required'],
             [['website_id',], 'integer'],
             [['language'], 'string', 'max' => 15],
             [['name'], 'string', 'max' => 255],

--- a/views/base/buttons.php
+++ b/views/base/buttons.php
@@ -21,6 +21,7 @@ use yii\helpers\Html;
             'name' => 'go_to_parent',
             'value' => '1',
             'class' => $model->isNewRecord ? 'btn btn-success' : 'btn btn-primary',
+            'disabled' => $model->contentTree->depth == 0
         ]) ?>
     <?php echo Html::submitButton(Yii::t('intermundiacms',
         $model->isNewRecord ? 'Create and stay' : 'Update and stay'),


### PR DESCRIPTION
Save images/files of website to directly @storage/web/source/[[attribute_language]] folder,
Prevent including website alias in children file manager items alias_path,
Make website title field required, since it determines
the alias and alias path of website Content Tree,
Disable "Update and go to parent" button when updating website