### PR TITLE
fix findContentTreeByFullPath() method

### DIFF
--- a/controllers/FrontendContentTreeController.php
+++ b/controllers/FrontendContentTreeController.php
@@ -244,6 +244,7 @@ class FrontendContentTreeController extends Controller
             if ($contentTreeId) {
                 $contentTree = ContentTree::find()
                     ->byId($contentTreeId)
+                    ->byTableName($pageTableName)
                     ->notHidden()
                     ->notDeleted()
                     ->one();


### PR DESCRIPTION
select contentTree by full path only if contentTree table_name is page